### PR TITLE
Fix access to static private field

### DIFF
--- a/src/PhpUnit/CriteriaComparator.php
+++ b/src/PhpUnit/CriteriaComparator.php
@@ -37,7 +37,7 @@ class CriteriaComparator extends ObjectComparator
      */
     public static function register()
     {
-        if (!static::$registered) {
+        if (!self::$registered) {
             self::$registered = true;
             Factory::getInstance()->register(new static());
         }


### PR DESCRIPTION
Using late static binding for a private property is broken, because it means that the property will be accessed on the called class and child classes cannot access private properties.